### PR TITLE
Added vi as Vietnamese code language

### DIFF
--- a/src/l10n/index.ts
+++ b/src/l10n/index.ts
@@ -125,6 +125,7 @@ const l10n: Record<key, CustomLocale> = {
   th,
   tr,
   uk,
+  vi: vn,
   vn,
   zh,
   zh_tw: zhTw,

--- a/src/l10n/vn.ts
+++ b/src/l10n/vn.ts
@@ -58,6 +58,6 @@ export const Vietnamese: CustomLocale = {
   rangeSeparator: " đến ",
 };
 
-fp.l10ns.vn = Vietnamese;
+fp.l10ns.vn = fp.l10ns.vi = Vietnamese;
 
 export default fp.l10ns;

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -172,6 +172,7 @@ export type key =
   | "th"
   | "tr"
   | "uk"
+  | "vi"
   | "vn"
   | "zh"
   | "uz"


### PR DESCRIPTION
This Pull Request will also add vi as a code language for vietnamese since vn is the current one but the ISO code is vi.