### PR TITLE
Fix issue onblur event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1624,9 +1624,12 @@ function FlatpickrInstance(
 
   function onBlur(e: FocusEvent) {
     const isInput = e.target === self._input;
-    const clonedInput = self.input.closest('.flatpickr-input') as HTMLElement;
-    const clonedInputValue = clonedInput.getAttribute('value') as string;
-    const valueChanged = self._input.value.trimEnd() !== self.formatDate(new Date(clonedInputValue), self.config.altFormat);
+    let valueChanged = true;
+    
+    if (self.config.altInput) {
+      const hiddenInputValue = self.element.getAttribute('value') as string;
+      valueChanged = self._input.value.trimEnd() !== self.formatDate(new Date(hiddenInputValue), self.config.altFormat);
+    }
 
     if (
       isInput &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1624,7 +1624,9 @@ function FlatpickrInstance(
 
   function onBlur(e: FocusEvent) {
     const isInput = e.target === self._input;
-    const valueChanged = self._input.value.trimEnd() !== getDateStr();
+    const clonedInput = self.input.closest('.flatpickr-input') as HTMLElement;
+    const clonedInputValue = clonedInput.getAttribute('value') as string;
+    const valueChanged = self._input.value.trimEnd() !== self.formatDate(new Date(clonedInputValue), self.config.altFormat);
 
     if (
       isInput &&


### PR DESCRIPTION
This isue was introduced with the v4.6.13 and the flatpickr loses the support of update the value when the blur event is triggered. This issue was introcuded on the commit https://github.com/flatpickr/flatpickr/issues/2668, with the validation of the input value and comparing dates.

The previous approach block the update of the values when a past date occur or typing, without press enter. The library just need to close the ballon to update the values. Now with the fix, we prevent the twice triggering of the event and update the value on close the ballon.