### PR TITLE
Improve accessibility and translations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,9 @@ function FlatpickrInstance(
 
         return self.l10n.daysInMonth[month];
       },
+      generateUniqueId() {
+        return Math.random().toString(36);
+      }
     };
   }
 
@@ -520,7 +523,11 @@ function FlatpickrInstance(
     bind(window.document, "focus", documentClick, { capture: true });
 
     if (self.config.clickOpens === true) {
-      bind(self._input, "click", self.open);
+      if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
+        bind(self._input, "focus", self.open);
+      } else {
+        bind(self._input, "click", self.open);
+      }
     }
 
     if (self.daysContainer !== undefined) {
@@ -653,6 +660,11 @@ function FlatpickrInstance(
       "div",
       "flatpickr-calendar"
     );
+    self.calendarContainer.id = 'flatpickr-calendar-' + self.utils.generateUniqueId();
+    self.calendarContainer.role = 'dialog';
+    self.calendarContainer.ariaModal = 'true';
+    self.calendarContainer.ariaLabel = self.l10n.ariaLabelCalendar;
+    self.altInput?.setAttribute('aria-controls', self.calendarContainer.id);
     self.calendarContainer.tabIndex = -1;
 
     if (!self.config.noCalendar) {
@@ -1181,6 +1193,9 @@ function FlatpickrInstance(
     self.prevMonthNav.innerHTML = self.config.prevArrow;
     self.nextMonthNav.innerHTML = self.config.nextArrow;
 
+    self.prevMonthNav.ariaLabel = self.l10n.prevMonth;
+    self.nextMonthNav.ariaLabel = self.l10n.nextMonth;
+
     buildMonths();
 
     Object.defineProperty(self, "_hidePrevMonthArrow", {
@@ -1315,6 +1330,7 @@ function FlatpickrInstance(
       );
       self.amPM.title = self.l10n.toggleTitle;
       self.amPM.tabIndex = self.isOpen ? 0 : -1;
+      self.amPM.ariaLive = "polite";
       self.timeContainer.appendChild(self.amPM);
     }
 
@@ -1447,6 +1463,7 @@ function FlatpickrInstance(
         self.calendarContainer.classList.remove("open");
       }
       if (self._input !== undefined) {
+        self._input.ariaExpanded = "false";
         self._input.classList.remove("active");
       }
     }
@@ -2030,6 +2047,7 @@ function FlatpickrInstance(
 
     if (!wasOpen) {
       self.calendarContainer.classList.add("open");
+      self._input.ariaExpanded = "true";
       self._input.classList.add("active");
       triggerEvent("onOpen");
       positionCalendar(positionElement);
@@ -2737,6 +2755,13 @@ function FlatpickrInstance(
       self.altInput.required = self.input.required;
       self.altInput.tabIndex = self.input.tabIndex;
       self.altInput.type = "text";
+
+      // add accessibility attributes
+      self.altInput.role = 'combobox';
+      self.altInput.ariaHasPopup = 'true';
+      self.altInput.ariaAutoComplete = 'none';
+      self.altInput.ariaExpanded = 'false';
+
       self.input.setAttribute("type", "hidden");
 
       if (!self.config.static && self.input.parentNode)
@@ -2767,7 +2792,7 @@ function FlatpickrInstance(
       "input",
       self.input.className + " flatpickr-mobile"
     );
-    self.mobileInput.tabIndex = 1;
+    self.mobileInput.tabIndex = 0;
     self.mobileInput.type = inputType;
     self.mobileInput.disabled = self.input.disabled;
     self.mobileInput.required = self.input.required;

--- a/src/index.ts
+++ b/src/index.ts
@@ -523,6 +523,8 @@ function FlatpickrInstance(
     bind(window.document, "focus", documentClick, { capture: true });
 
     if (self.config.clickOpens === true) {
+      // To provide a better experience for the use of assistive technologies in mobile devices,
+      // Let's bind the handler to the focus event instead of click event.
       if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
         bind(self._input, "focus", self.open);
       } else {

--- a/src/l10n/ar-dz.ts
+++ b/src/l10n/ar-dz.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const AlgerianArabic: CustomLocale = {
+  nextMonth: "الشهر القادم",
+  prevMonth: "الشهر السابق",
+  ariaLabelCalendar: "التقويم",
   weekdays: {
     shorthand: ["أحد", "اثنين", "ثلاثاء", "أربعاء", "خميس", "جمعة", "سبت"],
     longhand: [

--- a/src/l10n/ar.ts
+++ b/src/l10n/ar.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Arabic: CustomLocale = {
+  nextMonth: "الشهر القادم",
+  prevMonth: "الشهر السابق",
+  ariaLabelCalendar: "التقويم",
   weekdays: {
     shorthand: ["أحد", "اثنين", "ثلاثاء", "أربعاء", "خميس", "جمعة", "سبت"],
     longhand: [

--- a/src/l10n/at.ts
+++ b/src/l10n/at.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Austria: CustomLocale = {
+  nextMonth: "Nächster Monat",
+  prevMonth: "Vormonat",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
     longhand: [

--- a/src/l10n/az.ts
+++ b/src/l10n/az.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Azerbaijan: CustomLocale = {
+  nextMonth: "Növbəti ay",
+  prevMonth: "Əvvəlki ay",
+  ariaLabelCalendar: "Təqvim",
   weekdays: {
     shorthand: ["B.", "B.e.", "Ç.a.", "Ç.", "C.a.", "C.", "Ş."],
     longhand: [

--- a/src/l10n/be.ts
+++ b/src/l10n/be.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Belarusian: CustomLocale = {
+  nextMonth: "Наступны месяц",
+  prevMonth: "Мінулы месяц",
+  ariaLabelCalendar: "Каляндар",
   weekdays: {
     shorthand: ["Нд", "Пн", "Аў", "Ср", "Чц", "Пт", "Сб"],
     longhand: [

--- a/src/l10n/bg.ts
+++ b/src/l10n/bg.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Bulgarian: CustomLocale = {
+  nextMonth: "Следващия месец",
+  prevMonth: "Предишния месец",
+  ariaLabelCalendar: "Календар",
   weekdays: {
     shorthand: ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
     longhand: [

--- a/src/l10n/bn.ts
+++ b/src/l10n/bn.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Bangla: CustomLocale = {
+  nextMonth: "পরবর্তী মাস",
+  prevMonth: "আগের মাস",
+  ariaLabelCalendar: "পঞ্জিকা",
   weekdays: {
     shorthand: ["রবি", "সোম", "মঙ্গল", "বুধ", "বৃহস্পতি", "শুক্র", "শনি"],
     longhand: [

--- a/src/l10n/bs.ts
+++ b/src/l10n/bs.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Bosnian: CustomLocale = {
+  nextMonth: "Sljedeći mjesec",
+  prevMonth: "Prethodni mjesec",
+  ariaLabelCalendar: "Kalendar",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/cat.ts
+++ b/src/l10n/cat.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Catalan: CustomLocale = {
+  nextMonth: "El mes següent",
+  prevMonth: "El mes anterior",
+  ariaLabelCalendar: "Calendari",
   weekdays: {
     shorthand: ["Dg", "Dl", "Dt", "Dc", "Dj", "Dv", "Ds"],
     longhand: [

--- a/src/l10n/ckb.ts
+++ b/src/l10n/ckb.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Kurdish: CustomLocale = {
+  nextMonth: "مانگای داهاتو",
+  prevMonth: "مانگی پێشوو",
+  ariaLabelCalendar: "هەفتۆ",
   weekdays: {
     shorthand: [
       "یەکشەممە",

--- a/src/l10n/cs.ts
+++ b/src/l10n/cs.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Czech: CustomLocale = {
+  nextMonth: "Příští měsíc",
+  prevMonth: "Minulý měsíc",
+  ariaLabelCalendar: "Kalendář",
   weekdays: {
     shorthand: ["Ne", "Po", "Út", "St", "Čt", "Pá", "So"],
     longhand: [

--- a/src/l10n/cy.ts
+++ b/src/l10n/cy.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Welsh: CustomLocale = {
+  nextMonth: "Mis nesaf",
+  prevMonth: "Mis blaenorol",
+  ariaLabelCalendar: "Calendr",
   weekdays: {
     shorthand: ["Sul", "Llun", "Maw", "Mer", "Iau", "Gwe", "Sad"],
     longhand: [

--- a/src/l10n/da.ts
+++ b/src/l10n/da.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Danish: CustomLocale = {
+  nextMonth: "Næste måned",
+  prevMonth: "Forrige måned",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["søn", "man", "tir", "ons", "tors", "fre", "lør"],
     longhand: [

--- a/src/l10n/de.ts
+++ b/src/l10n/de.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const German: CustomLocale = {
+  nextMonth: "Nächster Monat",
+  prevMonth: "Vormonat",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
     longhand: [

--- a/src/l10n/default.ts
+++ b/src/l10n/default.ts
@@ -1,6 +1,9 @@
 import { Locale } from "../types/locale";
 
 export const english: Locale = {
+  nextMonth: "Next month",
+  prevMonth: "PRevious month",
+  ariaLabelCalendar: "Calendar",
   weekdays: {
     shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
     longhand: [

--- a/src/l10n/default.ts
+++ b/src/l10n/default.ts
@@ -2,7 +2,7 @@ import { Locale } from "../types/locale";
 
 export const english: Locale = {
   nextMonth: "Next month",
-  prevMonth: "PRevious month",
+  prevMonth: "Previous month",
   ariaLabelCalendar: "Calendar",
   weekdays: {
     shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],

--- a/src/l10n/eo.ts
+++ b/src/l10n/eo.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Esperanto: CustomLocale = {
+  nextMonth: "Venonta monato",
+  prevMonth: "Antaŭa monato",
+  ariaLabelCalendar: "Kalendaro",
   firstDayOfWeek: 1,
 
   rangeSeparator: " ĝis ",

--- a/src/l10n/es.ts
+++ b/src/l10n/es.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Spanish: CustomLocale = {
+  nextMonth: "El próximo mes",
+  prevMonth: "El mes anterior",
+  ariaLabelCalendar: "Calendario",
   weekdays: {
     shorthand: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
     longhand: [

--- a/src/l10n/et.ts
+++ b/src/l10n/et.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Estonian: CustomLocale = {
+  nextMonth: "Järgmine kuu",
+  prevMonth: "Eelmine kuu",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["P", "E", "T", "K", "N", "R", "L"],
     longhand: [

--- a/src/l10n/fa.ts
+++ b/src/l10n/fa.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Persian: CustomLocale = {
+  nextMonth: "ماه بعدی",
+  prevMonth: "ماه گذشته",
+  ariaLabelCalendar: "تقویم",
   weekdays: {
     shorthand: ["یک", "دو", "سه", "چهار", "پنج", "جمعه", "شنبه"],
     longhand: [

--- a/src/l10n/fi.ts
+++ b/src/l10n/fi.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Finnish: CustomLocale = {
+  nextMonth: "Ensi kuussa",
+  prevMonth: "Edellinen kuukausi",
+  ariaLabelCalendar: "Kalenteri",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/fo.ts
+++ b/src/l10n/fo.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Faroese: CustomLocale = {
+  nextMonth: "Næsta mánaði",
+  prevMonth: "Fyrra mánaði",
+  ariaLabelCalendar: "Kalendari",
   weekdays: {
     shorthand: ["Sun", "Mán", "Týs", "Mik", "Hós", "Frí", "Ley"],
     longhand: [

--- a/src/l10n/fr.ts
+++ b/src/l10n/fr.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const French: CustomLocale = {
+  nextMonth: "Le mois prochain",
+  prevMonth: "Le mois précédent",
+  ariaLabelCalendar: "Calendrier",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/ga.ts
+++ b/src/l10n/ga.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Irish: CustomLocale = {
+  nextMonth: "An mhí seo chugainn",
+  prevMonth: "An mhí seo caite",
+  ariaLabelCalendar: "An Féilire",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/gr.ts
+++ b/src/l10n/gr.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Greek: CustomLocale = {
+  nextMonth: "Τον επόμενο μήνα",
+  prevMonth: "Τον προηγούμενο μήνα",
+  ariaLabelCalendar: "Ημερολόγιο",
   weekdays: {
     shorthand: ["Κυ", "Δε", "Τρ", "Τε", "Πέ", "Πα", "Σά"],
     longhand: [

--- a/src/l10n/he.ts
+++ b/src/l10n/he.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Hebrew: CustomLocale = {
+  nextMonth: "החודש הבא",
+  prevMonth: "החודש הקודם",
+  ariaLabelCalendar: "לוח שנה",
   weekdays: {
     shorthand: ["א", "ב", "ג", "ד", "ה", "ו", "ש"],
     longhand: ["ראשון", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת"],

--- a/src/l10n/hi.ts
+++ b/src/l10n/hi.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Hindi: CustomLocale = {
+  nextMonth: "अगले महीने",
+  prevMonth: "पिछले महीने",
+  ariaLabelCalendar: "कैलेंडर",
   weekdays: {
     shorthand: ["रवि", "सोम", "मंगल", "बुध", "गुरु", "शुक्र", "शनि"],
     longhand: [

--- a/src/l10n/hr.ts
+++ b/src/l10n/hr.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Croatian: CustomLocale = {
+  nextMonth: "Sljedeći mjesec",
+  prevMonth: "Prošli mjesec",
+  ariaLabelCalendar: "Kalendar",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/hu.ts
+++ b/src/l10n/hu.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Hungarian: CustomLocale = {
+  nextMonth: "Következő hónap",
+  prevMonth: "Előző hónap",
+  ariaLabelCalendar: "Naptár",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/hy.ts
+++ b/src/l10n/hy.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Armenian: CustomLocale = {
+  nextMonth: "Հաջորդ ամիս",
+  prevMonth: "Նախորդ ամիս",
+  ariaLabelCalendar: "Օրացույց",
   weekdays: {
     shorthand: ["Կիր", "Երկ", "Երք", "Չրք", "Հնգ", "Ուրբ", "Շբթ"],
     longhand: [

--- a/src/l10n/id.ts
+++ b/src/l10n/id.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Indonesian: CustomLocale = {
+  nextMonth: "Bulan depan",
+  prevMonth: "Bulan sebelumnya",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"],
     longhand: ["Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"],

--- a/src/l10n/is.ts
+++ b/src/l10n/is.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Icelandic: CustomLocale = {
+  nextMonth: "Næsti mánuður",
+  prevMonth: "Síðasti mánuður",
+  ariaLabelCalendar: "Dagatal",
   weekdays: {
     shorthand: ["Sun", "Mán", "Þri", "Mið", "Fim", "Fös", "Lau"],
     longhand: [

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Italian: CustomLocale = {
+  nextMonth: "Il prossimo mese",
+  prevMonth: "Il mese scorso",
+  ariaLabelCalendar: "Calendario",
   weekdays: {
     shorthand: ["Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"],
     longhand: [

--- a/src/l10n/ja.ts
+++ b/src/l10n/ja.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Japanese: CustomLocale = {
+  nextMonth: "来月",
+  prevMonth: "前月",
+  ariaLabelCalendar: "カレンダー",
   weekdays: {
     shorthand: ["日", "月", "火", "水", "木", "金", "土"],
     longhand: [

--- a/src/l10n/ka.ts
+++ b/src/l10n/ka.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Georgian: CustomLocale = {
+  nextMonth: "შემდეგი თვე",
+  prevMonth: "წინა თვე",
+  ariaLabelCalendar: "კალენდარი",
   weekdays: {
     shorthand: ["კვ", "ორ", "სა", "ოთ", "ხუ", "პა", "შა"],
     longhand: [

--- a/src/l10n/km.ts
+++ b/src/l10n/km.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Khmer: CustomLocale = {
+  nextMonth: "ខែក្រោយ",
+  prevMonth: "ខែមុន",
+  ariaLabelCalendar: "ប្រតិទិន",
   weekdays: {
     shorthand: ["អាទិត្យ", "ចន្ទ", "អង្គារ", "ពុធ", "ព្រហស.", "សុក្រ", "សៅរ៍"],
     longhand: [

--- a/src/l10n/ko.ts
+++ b/src/l10n/ko.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Korean: CustomLocale = {
+  nextMonth: "다음 달",
+  prevMonth: "지난 달",
+  ariaLabelCalendar: "달력",
   weekdays: {
     shorthand: ["일", "월", "화", "수", "목", "금", "토"],
     longhand: [

--- a/src/l10n/kz.ts
+++ b/src/l10n/kz.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Kazakh: CustomLocale = {
+  nextMonth: "Келесі ай",
+  prevMonth: "Алдыңғы ай",
+  ariaLabelCalendar: "Таңбалар",
   weekdays: {
     shorthand: ["Жс", "Дс", "Сc", "Ср", "Бс", "Жм", "Сб"],
     longhand: [

--- a/src/l10n/lt.ts
+++ b/src/l10n/lt.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Lithuanian: CustomLocale = {
+  nextMonth: "Kitą mėnesį",
+  prevMonth: "Praėjusį mėnesį",
+  ariaLabelCalendar: "Kalendorius",
   weekdays: {
     shorthand: ["S", "Pr", "A", "T", "K", "Pn", "Š"],
     longhand: [

--- a/src/l10n/lv.ts
+++ b/src/l10n/lv.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Latvian: CustomLocale = {
+  nextMonth: "Nākamajā mēnesī",
+  prevMonth: "Iepriekšējajā mēnesī",
+  ariaLabelCalendar: "Kalendārs",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/mk.ts
+++ b/src/l10n/mk.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Macedonian: CustomLocale = {
+  nextMonth: "Следен месец",
+  prevMonth: "Претходен месец",
+  ariaLabelCalendar: "Календар",
   weekdays: {
     shorthand: ["Не", "По", "Вт", "Ср", "Че", "Пе", "Са"],
     longhand: [

--- a/src/l10n/mn.ts
+++ b/src/l10n/mn.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Mongolian: CustomLocale = {
+  nextMonth: "Дараа сар",
+  prevMonth: "Өнгөрсөн сар",
+  ariaLabelCalendar: "Календарь",
   firstDayOfWeek: 1,
   weekdays: {
     shorthand: ["Да", "Мя", "Лх", "Пү", "Ба", "Бя", "Ня"],

--- a/src/l10n/ms.ts
+++ b/src/l10n/ms.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Malaysian: CustomLocale = {
+  nextMonth: "Bulan depan",
+  prevMonth: "Bulan sebelumnya",
+  ariaLabelCalendar: "Kalendar",
   weekdays: {
     shorthand: ["Aha", "Isn", "Sel", "Rab", "Kha", "Jum", "Sab"],
     longhand: ["Ahad", "Isnin", "Selasa", "Rabu", "Khamis", "Jumaat", "Sabtu"],

--- a/src/l10n/my.ts
+++ b/src/l10n/my.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Burmese: CustomLocale = {
+  nextMonth: "နောက်တစ်ရာလ",
+  prevMonth: "နောက်ဆယ်လ",
+  ariaLabelCalendar: "ပြက္ခဒိန်",
   weekdays: {
     shorthand: ["နွေ", "လာ", "ဂါ", "ဟူး", "ကြာ", "သော", "နေ"],
     longhand: [

--- a/src/l10n/nl.ts
+++ b/src/l10n/nl.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Dutch: CustomLocale = {
+  nextMonth: "Volgende maand",
+  prevMonth: "Vorige maand",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["zo", "ma", "di", "wo", "do", "vr", "za"],
     longhand: [

--- a/src/l10n/nn.ts
+++ b/src/l10n/nn.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const NorwegianNynorsk: CustomLocale = {
+  nextMonth: "Neste månad",
+  prevMonth: "Førre månad",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["Sø.", "Må.", "Ty.", "On.", "To.", "Fr.", "La."],
     longhand: [

--- a/src/l10n/no.ts
+++ b/src/l10n/no.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Norwegian: CustomLocale = {
+  nextMonth: "Neste måned",
+  prevMonth: "Forrige måned",
+  ariaLabelCalendar: "Kalender",
   weekdays: {
     shorthand: ["Søn", "Man", "Tir", "Ons", "Tor", "Fre", "Lør"],
     longhand: [

--- a/src/l10n/pa.ts
+++ b/src/l10n/pa.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Punjabi: CustomLocale = {
+  nextMonth: "ਅਗਲੇ ਮਹੀਨੇ",
+  prevMonth: "ਪਿਛਲੇ ਮਹੀਨੇ",
+  ariaLabelCalendar: "ਕੈਲੰਡਰ",
   weekdays: {
     shorthand: ["ਐਤ", "ਸੋਮ", "ਮੰਗਲ", "ਬੁੱਧ", "ਵੀਰ", "ਸ਼ੁੱਕਰ", "ਸ਼ਨਿੱਚਰ"],
     longhand: [

--- a/src/l10n/pl.ts
+++ b/src/l10n/pl.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Polish: CustomLocale = {
+  nextMonth: "Następny miesiąc",
+  prevMonth: "Poprzedni miesiąc",
+  ariaLabelCalendar: "Kalendarz",
   weekdays: {
     shorthand: ["Nd", "Pn", "Wt", "Śr", "Cz", "Pt", "So"],
     longhand: [

--- a/src/l10n/pt.ts
+++ b/src/l10n/pt.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Portuguese: CustomLocale = {
+  nextMonth: "Próximo mês",
+  prevMonth: "Mês anterior",
+  ariaLabelCalendar: "Calendário",
   weekdays: {
     shorthand: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
     longhand: [

--- a/src/l10n/ro.ts
+++ b/src/l10n/ro.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Romanian: CustomLocale = {
+  nextMonth: "Luna viitoare",
+  prevMonth: "Luna trecută",
+  ariaLabelCalendar: "Calendar",
   weekdays: {
     shorthand: ["Dum", "Lun", "Mar", "Mie", "Joi", "Vin", "Sâm"],
     longhand: [

--- a/src/l10n/ru.ts
+++ b/src/l10n/ru.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Russian: CustomLocale = {
+  nextMonth: "Следующий месяц",
+  prevMonth: "Прошлый месяц",
+  ariaLabelCalendar: "Календарь",
   weekdays: {
     shorthand: ["Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
     longhand: [

--- a/src/l10n/si.ts
+++ b/src/l10n/si.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Sinhala: CustomLocale = {
+  nextMonth: "මාසය ඉරණයේ",
+  prevMonth: "පෙර මාසය",
+  ariaLabelCalendar: "දින දර්ශනය",
   weekdays: {
     shorthand: ["ඉ", "ස", "අ", "බ", "බ්‍ර", "සි", "සෙ"],
     longhand: [

--- a/src/l10n/sk.ts
+++ b/src/l10n/sk.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Slovak: CustomLocale = {
+  nextMonth: "Budúci mesiac",
+  prevMonth: "Minulý mesiac",
+  ariaLabelCalendar: "Kalendár",
   weekdays: {
     shorthand: ["Ned", "Pon", "Ut", "Str", "Štv", "Pia", "Sob"],
     longhand: [

--- a/src/l10n/sl.ts
+++ b/src/l10n/sl.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Slovenian: CustomLocale = {
+  nextMonth: "Naslednji mesec",
+  prevMonth: "Prejšnji mesec",
+  ariaLabelCalendar: "Koledar",
   weekdays: {
     shorthand: ["Ned", "Pon", "Tor", "Sre", "Čet", "Pet", "Sob"],
     longhand: [

--- a/src/l10n/sq.ts
+++ b/src/l10n/sq.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Albanian: CustomLocale = {
+  nextMonth: "Muaji tjetër",
+  prevMonth: "Muaji i kaluar",
+  ariaLabelCalendar: "Kalendar",
   weekdays: {
     shorthand: ["Di", "Hë", "Ma", "Më", "En", "Pr", "Sh"],
     longhand: [

--- a/src/l10n/sr-cyr.ts
+++ b/src/l10n/sr-cyr.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const SerbianCyrillic: CustomLocale = {
+  nextMonth: "Следећи месец",
+  prevMonth: "Претходни месец",
+  ariaLabelCalendar: "Календар",
   weekdays: {
     shorthand: ["Нед", "Пон", "Уто", "Сре", "Чет", "Пет", "Суб"],
     longhand: [

--- a/src/l10n/sr.ts
+++ b/src/l10n/sr.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Serbian: CustomLocale = {
+  nextMonth: "Следећи месец",
+  prevMonth: "Претходни месец",
+  ariaLabelCalendar: "Календар",
   weekdays: {
     shorthand: ["Ned", "Pon", "Uto", "Sre", "Čet", "Pet", "Sub"],
     longhand: [

--- a/src/l10n/sv.ts
+++ b/src/l10n/sv.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Swedish: CustomLocale = {
+  nextMonth: "Nästa månad",
+  prevMonth: "Förra månaden",
+  ariaLabelCalendar: "Kalender",
   firstDayOfWeek: 1,
   weekAbbreviation: "v",
 

--- a/src/l10n/th.ts
+++ b/src/l10n/th.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Thai: CustomLocale = {
+  nextMonth: "เดือนถัดไป",
+  prevMonth: "เดือนที่แล้ว",
+  ariaLabelCalendar: "ปฏิทิน",
   weekdays: {
     shorthand: ["อา", "จ", "อ", "พ", "พฤ", "ศ", "ส"],
     longhand: [

--- a/src/l10n/tr.ts
+++ b/src/l10n/tr.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Turkish: CustomLocale = {
+  nextMonth: "Gelecek ay",
+  prevMonth: "Önceki ay",
+  ariaLabelCalendar: "Takvim",
   weekdays: {
     shorthand: ["Paz", "Pzt", "Sal", "Çar", "Per", "Cum", "Cmt"],
     longhand: [

--- a/src/l10n/uk.ts
+++ b/src/l10n/uk.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Ukrainian: CustomLocale = {
+  nextMonth: "Наступний місяць",
+  prevMonth: "Минулий місяць",
+  ariaLabelCalendar: "Календар",
   firstDayOfWeek: 1,
 
   weekdays: {

--- a/src/l10n/uz.ts
+++ b/src/l10n/uz.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Uzbek: CustomLocale = {
+  nextMonth: "Keyingi oy",
+  prevMonth: "Oldingi oy",
+  ariaLabelCalendar: "Taqvim",
   weekdays: {
     shorthand: ["Якш", "Душ", "Сеш", "Чор", "Пай", "Жум", "Шан"],
     longhand: [

--- a/src/l10n/uz_latn.ts
+++ b/src/l10n/uz_latn.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const UzbekLatin: CustomLocale = {
+  nextMonth: "Keyingi oy",
+  prevMonth: "Oldingi oy",
+  ariaLabelCalendar: "Taqvim",
   weekdays: {
     shorthand: ["Ya", "Du", "Se", "Cho", "Pa", "Ju", "Sha"],
     longhand: [

--- a/src/l10n/vn.ts
+++ b/src/l10n/vn.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Vietnamese: CustomLocale = {
+  nextMonth: "Tháng tiếp theo",
+  prevMonth: "Tháng trước",
+  ariaLabelCalendar: "Lịch",
   weekdays: {
     shorthand: ["CN", "T2", "T3", "T4", "T5", "T6", "T7"],
     longhand: [

--- a/src/l10n/zh.ts
+++ b/src/l10n/zh.ts
@@ -10,6 +10,9 @@ const fp =
       } as FlatpickrFn);
 
 export const Mandarin: CustomLocale = {
+  nextMonth: "下个月",
+  prevMonth: "上个月",
+  ariaLabelCalendar: "日历",
   weekdays: {
     shorthand: ["周日", "周一", "周二", "周三", "周四", "周五", "周六"],
     longhand: [

--- a/src/l10n/zh_tw.ts
+++ b/src/l10n/zh_tw.ts
@@ -8,6 +8,9 @@ const fp =
         l10ns: {},
       } as FlatpickrFn);
 export const MandarinTraditional: CustomLocale = {
+  nextMonth: "下個月",
+  prevMonth: "上個月",
+  ariaLabelCalendar: "行事曆",
   weekdays: {
     shorthand: ["週日", "週一", "週二", "週三", "週四", "週五", "週六"],
     longhand: [

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -149,6 +149,7 @@ export type Instance = Elements &
 
     utils: {
       getDaysInMonth: (month?: number, year?: number) => number;
+      generateUniqueId: () => string;
     };
   };
 

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -1,4 +1,7 @@
 export type Locale = {
+  nextMonth: string,
+  prevMonth: string,
+  ariaLabelCalendar: string,
   weekdays: {
     shorthand: [string, string, string, string, string, string, string];
     longhand: [string, string, string, string, string, string, string];
@@ -75,6 +78,9 @@ export type CustomLocale = {
   minuteAriaLabel?: string;
   amPM?: Locale["amPM"];
   time_24hr?: Locale["time_24hr"];
+  nextMonth: string,
+  prevMonth: string,
+  ariaLabelCalendar: string,
   weekdays: {
     shorthand: [string, string, string, string, string, string, string];
     longhand: [string, string, string, string, string, string, string];


### PR DESCRIPTION
This PR is for implement the accessibility improvements for the Flatpickr

### What was done:
- Added aria-attributes to the input and the calendar dialog to follow the accessibility requirements form W3.org.
- Added a label to the previous and next month buttons.
- Added the translations for all the new labels.
- Improved the behavior of the datepicker when used in the not native mode, and with using Talkback:
	- Instead of bind the opne method to the click event, we bind it to the focus event. This way, when using the talkback the editable datepicker open with double tap, and the readonly datepicker open with double tap and hold.
- Added the aria-live attribute in polite mode to the am/pm spin button, so the screen reader inform when it changes.
- Changed the tabIndex of the mobile input from 1 to 0 to follow the best practices.