### PR TITLE
Improve MonthPicker plugin A11Y

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,12 +167,6 @@ function FlatpickrInstance(
       (e: KeyboardEvent) => {
         if (e.key === "Tab") {
           if (e.shiftKey) {
-            //shift+tab pressed
-            if (self.loadedPlugins.indexOf("monthSelect") !== -1) {
-              setTimeout(() => {
-                focusOnAvailableMonth();
-              }, 0);
-            }
             return;
           } else {
             _predictableTopElement.focus();
@@ -3034,12 +3028,7 @@ function FlatpickrInstance(
         if (e.shiftKey) return;
         e.preventDefault();
 
-        // If using month plugin, focus on available month, otherwise focus on available day
-        if (self.loadedPlugins.indexOf("monthSelect") !== -1) {
-          focusOnAvailableMonth();
-        } else {
-          focusOnDay(getFirstAvailableDay(1), 0);
-        }
+        focusOnDay(getFirstAvailableDay(1), 0);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ function FlatpickrInstance(
       },
       generateUniqueId() {
         return Math.random().toString(36);
-      }
+      },
     };
   }
 
@@ -168,6 +168,11 @@ function FlatpickrInstance(
         if (e.key === "Tab") {
           if (e.shiftKey) {
             //shift+tab pressed
+            if (self.loadedPlugins.indexOf("monthSelect") !== -1) {
+              setTimeout(() => {
+                focusOnAvailableMonth();
+              }, 0);
+            }
             return;
           } else {
             _predictableTopElement.focus();
@@ -231,7 +236,7 @@ function FlatpickrInstance(
     if (self.selectedDates.length === 0) {
       const defaultDate =
         self.config.minDate === undefined ||
-          compareDates(new Date(), self.config.minDate) >= 0
+        compareDates(new Date(), self.config.minDate) >= 0
           ? new Date()
           : new Date(self.config.minDate.getTime());
 
@@ -299,7 +304,7 @@ function FlatpickrInstance(
         self.minDateHasTime &&
         self.latestSelectedDateObj &&
         compareDates(self.latestSelectedDateObj, self.config.minDate, true) ===
-        0);
+          0);
 
     const limitMaxHours =
       self.config.maxTime !== undefined ||
@@ -307,7 +312,7 @@ function FlatpickrInstance(
         self.maxDateHasTime &&
         self.latestSelectedDateObj &&
         compareDates(self.latestSelectedDateObj, self.config.maxDate, true) ===
-        0);
+          0);
 
     if (
       self.config.maxTime !== undefined &&
@@ -462,6 +467,8 @@ function FlatpickrInstance(
       self.open();
       if (self.config.noCalendar || self.isMobile) {
         self.hourElement?.focus();
+      } else if (self.loadedPlugins.indexOf("monthSelect") !== -1) {
+        focusOnAvailableMonth();
       } else {
         focusOnDay(getFirstAvailableDay(1), 0);
       }
@@ -533,7 +540,11 @@ function FlatpickrInstance(
     if (self.config.clickOpens === true) {
       // To provide a better experience for the use of assistive technologies in mobile devices,
       // Let's bind the handler to the focus event instead of click event.
-      if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
+      if (
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+          navigator.userAgent
+        )
+      ) {
         bind(self._input, "focus", self.open);
       } else {
         bind(self._input, "click", self.open);
@@ -596,9 +607,9 @@ function FlatpickrInstance(
       jumpDate !== undefined
         ? self.parseDate(jumpDate)
         : self.latestSelectedDateObj ||
-        (self.config.minDate && self.config.minDate > self.now
-          ? self.config.minDate
-          : self.config.maxDate && self.config.maxDate < self.now
+          (self.config.minDate && self.config.minDate > self.now
+            ? self.config.minDate
+            : self.config.maxDate && self.config.maxDate < self.now
             ? self.config.maxDate
             : self.now);
 
@@ -669,11 +680,12 @@ function FlatpickrInstance(
       "div",
       "flatpickr-calendar"
     );
-    self.calendarContainer.id = 'flatpickr-calendar-' + self.utils.generateUniqueId();
-    self.calendarContainer.role = 'dialog';
-    self.calendarContainer.ariaModal = 'true';
+    self.calendarContainer.id =
+      "flatpickr-calendar-" + self.utils.generateUniqueId();
+    self.calendarContainer.role = "dialog";
+    self.calendarContainer.ariaModal = "true";
     self.calendarContainer.ariaLabel = self.l10n.ariaLabelCalendar;
-    self.altInput?.setAttribute('aria-controls', self.calendarContainer.id);
+    self.altInput?.setAttribute("aria-controls", self.calendarContainer.id);
     self.calendarContainer.tabIndex = -1;
 
     if (!self.config.noCalendar) {
@@ -815,14 +827,14 @@ function FlatpickrInstance(
             dayElement,
             "startRange",
             self.selectedDates[0] &&
-            compareDates(date, self.selectedDates[0], true) === 0
+              compareDates(date, self.selectedDates[0], true) === 0
           );
 
           toggleClass(
             dayElement,
             "endRange",
             self.selectedDates[1] &&
-            compareDates(date, self.selectedDates[1], true) === 0
+              compareDates(date, self.selectedDates[1], true) === 0
           );
 
           if (className === "nextMonthDay") dayElement.classList.add("inRange");
@@ -895,8 +907,8 @@ function FlatpickrInstance(
         givenMonth - self.currentMonth === m
           ? current.$i + delta
           : delta < 0
-            ? month.children.length - 1
-            : 0;
+          ? month.children.length - 1
+          : 0;
       const numMonthDays = month.children.length;
 
       for (
@@ -927,12 +939,12 @@ function FlatpickrInstance(
       current !== undefined
         ? current
         : dayFocused
-          ? (activeElement as DayElement)
-          : self.selectedDateElem !== undefined && isInView(self.selectedDateElem)
-            ? self.selectedDateElem
-            : self.todayDateElem !== undefined && isInView(self.todayDateElem)
-              ? self.todayDateElem
-              : getFirstAvailableDay(offset > 0 ? 1 : -1);
+        ? (activeElement as DayElement)
+        : self.selectedDateElem !== undefined && isInView(self.selectedDateElem)
+        ? self.selectedDateElem
+        : self.todayDateElem !== undefined && isInView(self.todayDateElem)
+        ? self.todayDateElem
+        : getFirstAvailableDay(offset > 0 ? 1 : -1);
 
     if (startElem === undefined) {
       self._input.focus();
@@ -1174,7 +1186,7 @@ function FlatpickrInstance(
       self.monthElements = [];
     }
 
-    for (let m = self.config.showMonths; m--;) {
+    for (let m = self.config.showMonths; m--; ) {
       const month = buildMonth();
       self.yearElements.push(month.yearElement);
       self.monthElements.push(month.monthElement);
@@ -1266,8 +1278,8 @@ function FlatpickrInstance(
       self.latestSelectedDateObj
         ? self.latestSelectedDateObj.getHours()
         : self.config.time_24hr
-          ? defaults.hours
-          : military2ampm(defaults.hours)
+        ? defaults.hours
+        : military2ampm(defaults.hours)
     );
 
     self.minuteElement.value = pad(
@@ -1330,11 +1342,11 @@ function FlatpickrInstance(
         "span",
         "flatpickr-am-pm",
         self.l10n.amPM[
-        int(
-          (self.latestSelectedDateObj
-            ? self.hourElement.value
-            : self.config.defaultHour) > 11
-        )
+          int(
+            (self.latestSelectedDateObj
+              ? self.hourElement.value
+              : self.config.defaultHour) > 11
+          )
         ]
       );
       self.amPM.title = self.l10n.toggleTitle;
@@ -1354,7 +1366,7 @@ function FlatpickrInstance(
       );
     else clearNode(self.weekdayContainer);
 
-    for (let i = self.config.showMonths; i--;) {
+    for (let i = self.config.showMonths; i--; ) {
       const container = createElement<HTMLDivElement>(
         "div",
         "flatpickr-weekdaycontainer"
@@ -1383,7 +1395,7 @@ function FlatpickrInstance(
       ];
     }
 
-    for (let i = self.config.showMonths; i--;) {
+    for (let i = self.config.showMonths; i--; ) {
       self.weekdayContainer.children[i].innerHTML = `
       <span class='flatpickr-weekday'>
         ${weekdays.join("</span><span class='flatpickr-weekday'>")}
@@ -1485,7 +1497,7 @@ function FlatpickrInstance(
   function destroy() {
     if (self.config !== undefined) triggerEvent("onDestroy");
 
-    for (let i = self._handlers.length; i--;) {
+    for (let i = self._handlers.length; i--; ) {
       self._handlers[i].remove();
     }
 
@@ -1555,7 +1567,7 @@ function FlatpickrInstance(
     ] as (keyof Instance)[]).forEach((k) => {
       try {
         delete self[k as keyof Instance];
-      } catch (_) { }
+      } catch (_) {}
     });
   }
 
@@ -1912,8 +1924,8 @@ function FlatpickrInstance(
       return;
 
     const hoverDate = elem
-      ? elem.dateObj.getTime()
-      : (self.days.firstElementChild as DayElement).dateObj.getTime(),
+        ? elem.dateObj.getTime()
+        : (self.days.firstElementChild as DayElement).dateObj.getTime(),
       initialDate = (self.parseDate(
         self.selectedDates[0],
         undefined,
@@ -2083,7 +2095,7 @@ function FlatpickrInstance(
 
       const inverseDateObj =
         self.config[
-        `_${type === "min" ? "max" : "min"}Date` as "_minDate" | "_maxDate"
+          `_${type === "min" ? "max" : "min"}Date` as "_minDate" | "_maxDate"
         ];
 
       if (dateObj !== undefined) {
@@ -2279,16 +2291,17 @@ function FlatpickrInstance(
       ...(typeof self.config.locale === "object"
         ? self.config.locale
         : self.config.locale !== "default"
-          ? flatpickr.l10ns[self.config.locale as LocaleKey]
-          : undefined),
+        ? flatpickr.l10ns[self.config.locale as LocaleKey]
+        : undefined),
     };
 
     tokenRegex.D = `(${self.l10n.weekdays.shorthand.join("|")})`;
     tokenRegex.l = `(${self.l10n.weekdays.longhand.join("|")})`;
     tokenRegex.M = `(${self.l10n.months.shorthand.join("|")})`;
     tokenRegex.F = `(${self.l10n.months.longhand.join("|")})`;
-    tokenRegex.K = `(${self.l10n.amPM[0]}|${self.l10n.amPM[1]
-      }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;
+    tokenRegex.K = `(${self.l10n.amPM[0]}|${
+      self.l10n.amPM[1]
+    }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;
 
     const userConfig = {
       ...instanceConfig,
@@ -2316,10 +2329,10 @@ function FlatpickrInstance(
     const positionElement = customPositionElement || self._positionElement;
 
     const calendarHeight = Array.prototype.reduce.call(
-      self.calendarContainer.children,
-      ((acc: number, child: HTMLElement) => acc + child.offsetHeight) as any,
-      0
-    ) as number,
+        self.calendarContainer.children,
+        ((acc: number, child: HTMLElement) => acc + child.offsetHeight) as any,
+        0
+      ) as number,
       calendarWidth = self.calendarContainer.offsetWidth,
       configPos = self.config.position.split(" "),
       configPosVertical = configPos[0],
@@ -2465,7 +2478,7 @@ function FlatpickrInstance(
     const shouldChangeMonth =
       (selectedDate.getMonth() < self.currentMonth ||
         selectedDate.getMonth() >
-        self.currentMonth + self.config.showMonths - 1) &&
+          self.currentMonth + self.config.showMonths - 1) &&
       self.config.mode !== "range";
 
     self.selectedDateElem = target;
@@ -2620,8 +2633,8 @@ function FlatpickrInstance(
     self.selectedDates = (self.config.allowInvalidPreload
       ? dates
       : dates.filter(
-        (d) => d instanceof Date && isEnabled(d, false)
-      )) as Date[];
+          (d) => d instanceof Date && isEnabled(d, false)
+        )) as Date[];
 
     if (self.config.mode === "range")
       self.selectedDates.sort((a, b) => a.getTime() - b.getTime());
@@ -2694,8 +2707,8 @@ function FlatpickrInstance(
       self.config.defaultDate ||
       ((self.input.nodeName === "INPUT" ||
         self.input.nodeName === "TEXTAREA") &&
-        self.input.placeholder &&
-        self.input.value === self.input.placeholder
+      self.input.placeholder &&
+      self.input.value === self.input.placeholder
         ? null
         : self.input.value);
 
@@ -2706,11 +2719,11 @@ function FlatpickrInstance(
         ? self.selectedDates[0]
         : self.config.minDate &&
           self.config.minDate.getTime() > self.now.getTime()
-          ? self.config.minDate
-          : self.config.maxDate &&
-            self.config.maxDate.getTime() < self.now.getTime()
-            ? self.config.maxDate
-            : self.now;
+        ? self.config.minDate
+        : self.config.maxDate &&
+          self.config.maxDate.getTime() < self.now.getTime()
+        ? self.config.maxDate
+        : self.now;
 
     self.currentYear = self._initialDate.getFullYear();
     self.currentMonth = self._initialDate.getMonth();
@@ -2767,10 +2780,10 @@ function FlatpickrInstance(
       self.altInput.type = "text";
 
       // add accessibility attributes
-      self.altInput.role = 'combobox';
-      self.altInput.ariaHasPopup = 'true';
-      self.altInput.ariaAutoComplete = 'none';
-      self.altInput.ariaExpanded = 'false';
+      self.altInput.role = "combobox";
+      self.altInput.ariaHasPopup = "true";
+      self.altInput.ariaAutoComplete = "none";
+      self.altInput.ariaExpanded = "false";
 
       self.input.setAttribute("type", "hidden");
 
@@ -2812,8 +2825,8 @@ function FlatpickrInstance(
       inputType === "datetime-local"
         ? "Y-m-d\\TH:i:S"
         : inputType === "date"
-          ? "Y-m-d"
-          : "H:i:S";
+        ? "Y-m-d"
+        : "H:i:S";
 
     if (self.selectedDates.length > 0) {
       self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(
@@ -2840,7 +2853,7 @@ function FlatpickrInstance(
           self.mobileInput,
           self.input.nextSibling
         );
-    } catch { }
+    } catch {}
 
     bind(self.mobileInput, "change", (e: KeyboardEvent) => {
       self.setDate(
@@ -2985,8 +2998,25 @@ function FlatpickrInstance(
   }
 
   /**
-  * Method to change the month view when using keyboard on next/prev arrows
-  */
+   * Method to focus on the available month
+   */
+  function focusOnAvailableMonth() {
+    // Get selected month, first try selected, then get the first one
+    const targetMonth =
+      (self.calendarContainer?.querySelector(
+        ".flatpickr-monthSelect-month.selected"
+      ) as HTMLElement) ||
+      (self.calendarContainer?.querySelector(
+        ".flatpickr-monthSelect-month"
+      ) as HTMLElement);
+
+    // Focus on target month
+    targetMonth?.focus();
+  }
+
+  /**
+   * Method to change the month view when using keyboard on next/prev arrows
+   */
   function onMonthKeydown(e: KeyboardEvent) {
     const eventTarget = getEventTarget(e);
     const isPrevMonth = self.prevMonthNav.contains(eventTarget as Node);
@@ -2995,6 +3025,7 @@ function FlatpickrInstance(
     if (isPrevMonth || isNextMonth) {
       if (e.key === "Enter" || e.key === " ") {
         changeMonth(isPrevMonth ? -1 : 1);
+
         return;
       }
 
@@ -3003,7 +3034,12 @@ function FlatpickrInstance(
         if (e.shiftKey) return;
         e.preventDefault();
 
-        focusOnDay(getFirstAvailableDay(1), 0);
+        // If using month plugin, focus on available month, otherwise focus on available day
+        if (self.loadedPlugins.indexOf("monthSelect") !== -1) {
+          focusOnAvailableMonth();
+        } else {
+          focusOnDay(getFirstAvailableDay(1), 0);
+        }
       }
     }
   }

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -105,22 +105,40 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
     }
 
     function bindEvents() {
-      fp._bind(fp.prevMonthNav, "click", (e) => {
+      function onEventCallback(e: Event, isNext: boolean) {
         e.preventDefault();
         e.stopPropagation();
+        const targetYear = isNext ? fp.currentYear + 1 : fp.currentYear - 1;
+        const focusTarget = isNext ? fp.nextMonthNav : fp.prevMonthNav;
 
-        fp.changeYear(fp.currentYear - 1);
+        fp.changeYear(targetYear);
         selectYear();
         buildMonths();
+        focusTarget.focus();
+      }
+
+      fp._bind(fp.prevMonthNav, "click", (e) => {
+        onEventCallback(e, false);
       });
 
       fp._bind(fp.nextMonthNav, "click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
+        onEventCallback(e, true);
+      });
 
-        fp.changeYear(fp.currentYear + 1);
-        selectYear();
-        buildMonths();
+      fp._bind(fp.prevMonthNav, "keydown", (e) => {
+        if (e.keyCode === 13 || e.keyCode === 32) {
+          onEventCallback(e, false);
+        }
+      });
+
+      fp._bind(fp.nextMonthNav, "keydown", (e) => {
+        if (e.keyCode === 13 || e.keyCode === 32) {
+          onEventCallback(e, true);
+        } else if (e.keyCode === 9) {
+          if (!e.shiftKey) {
+            focusOnMonth();
+          }
+        }
       });
 
       fp._bind(
@@ -300,6 +318,26 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         self.monthsContainer.contains(document.activeElement)
       ) {
         setMonth((document.activeElement as MonthElement).dateObj);
+      }
+    }
+
+    function focusOnMonth() {
+      if (!fp.rContainer || !self.monthsContainer) return;
+
+      const currentlySelected = fp.rContainer.querySelector(
+        ".flatpickr-monthSelect-month.selected"
+      ) as HTMLElement;
+
+      let index = Array.prototype.indexOf.call(
+        self.monthsContainer.children,
+        document.activeElement
+      );
+
+      if (index === -1) {
+        const target =
+          currentlySelected || self.monthsContainer.firstElementChild;
+        target.focus();
+        index = (target as MonthElement).$i;
       }
     }
 

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -105,6 +105,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
     }
 
     function bindEvents() {
+      // Callback method to be used on following click and keydown events
       function onEventCallback(e: Event, isNext: boolean) {
         e.preventDefault();
         e.stopPropagation();
@@ -126,15 +127,18 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       });
 
       fp._bind(fp.prevMonthNav, "keydown", (e) => {
+        // If Space or Enter
         if (e.keyCode === 13 || e.keyCode === 32) {
           onEventCallback(e, false);
         }
       });
 
       fp._bind(fp.nextMonthNav, "keydown", (e) => {
+        // If Space or Enter
         if (e.keyCode === 13 || e.keyCode === 32) {
           onEventCallback(e, true);
         } else if (e.keyCode === 9) {
+          // If it's Tab, without shift, focus on available month
           if (!e.shiftKey) {
             focusOnMonth();
           }
@@ -328,17 +332,10 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         ".flatpickr-monthSelect-month.selected"
       ) as HTMLElement;
 
-      let index = Array.prototype.indexOf.call(
-        self.monthsContainer.children,
-        document.activeElement
-      );
-
-      if (index === -1) {
-        const target =
-          currentlySelected || self.monthsContainer.firstElementChild;
-        target.focus();
-        index = (target as MonthElement).$i;
-      }
+      // If a month is selected, focus on that, otherwise go to the first month
+      const target =
+        currentlySelected || self.monthsContainer.firstElementChild;
+      target.focus();
     }
 
     function closeHook() {


### PR DESCRIPTION
Added keyboard interaction for the Month plugin.

- Now its possible to use the tab to navigate between the header elements (year input and prev/next arrows).
- It has focus trap inside the calendar balloon.
- The mont navigation is done using arrows.