### PR TITLE
[ROU-3816]: Revert to fix a functional issue.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2023,6 +2023,10 @@ function FlatpickrInstance(
     e?: FocusEvent | MouseEvent,
     positionElement = self._positionElement
   ) {
+    if (self.input.disabled || self._input.disabled) {
+      return;
+    }
+
     if (self.isMobile === true) {
       if (e) {
         e.preventDefault();
@@ -2039,7 +2043,7 @@ function FlatpickrInstance(
 
       triggerEvent("onOpen");
       return;
-    } else if (self._input.disabled || self.config.inline) {
+    } else if (self.config.inline) {
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -531,13 +531,8 @@ function FlatpickrInstance(
     bind(window.document, "focus", documentClick, { capture: true });
 
     if (self.config.clickOpens === true) {
-      // To provide a better experience for the use of assistive technologies in mobile devices,
-      // Let's bind the handler to the focus event instead of click event.
-      if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
-        bind(self._input, "focus", self.open);
-      } else {
-        bind(self._input, "click", self.open);
-      }
+      bind(self._input, "focus", self.open);
+      bind(self._input, "click", self.open);
     }
 
     if (self.daysContainer !== undefined) {


### PR DESCRIPTION
This PR will fix a function issue due to a misbehaviour when DatePicker is closed at OnScroll, once at phone devices since at OnScroll focus will not change as it does when close on click, that way once we try to open it again, since focus didn't change it will not open!