### PR TITLE
ROU-4902: Fix issue when selecting a date in a calendar with disabled days

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2446,7 +2446,7 @@ function FlatpickrInstance(
   function selectDate(e: MouseEvent | KeyboardEvent) {
     e.preventDefault();
     e.stopPropagation();
-    onMouseOver(getEventTarget(e) as DayElement);
+    if (self.config.mode === "range") onMouseOver(getEventTarget(e) as DayElement);
 
     const isSelectable = (day: Element) =>
       day.classList &&


### PR DESCRIPTION
This PR fixes an issue that makes some dates disabled after selecting an initial date. This occurred when some dates were disabled (weekends for example).

### What was happening
- When selecting a date, the onMouseOver method was always called. The onMouseOver method contains logic related only to the range mode. When calling it for a picker in single date mode, some dates were blocked when they shouldn't have been.

### What was happening
- Added a validation to check if this is range mode before run the onMouseOver method.