### PR TITLE
ROU-4912: DatePicker insconsistent behaviour when deleting dates manually in edit mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,8 @@ function FlatpickrInstance(
   function updateTime(
     e?: MouseEvent | IncrementEvent | KeyboardEvent | FocusEvent
   ) {
-    if (self.selectedDates.length === 0) {
+    // Update the time only when the DatePicker has no Calendar i.e. it is in TimePicker mode
+    if (self.selectedDates.length === 0 && self.config.noCalendar) {
       const defaultDate =
         self.config.minDate === undefined ||
         compareDates(new Date(), self.config.minDate) >= 0
@@ -245,6 +246,7 @@ function FlatpickrInstance(
       self.selectedDates = [defaultDate];
       self.latestSelectedDateObj = defaultDate;
     }
+    
     if (e !== undefined && e.type !== "blur") {
       timeWrapper(e);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,6 @@ function FlatpickrInstance(
   function updateTime(
     e?: MouseEvent | IncrementEvent | KeyboardEvent | FocusEvent
   ) {
-    // Update the time only when the DatePicker has no Calendar i.e. it is in TimePicker mode
     if (self.selectedDates.length === 0) {
       const defaultDate =
         self.config.minDate === undefined ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ function FlatpickrInstance(
     e?: MouseEvent | IncrementEvent | KeyboardEvent | FocusEvent
   ) {
     // Update the time only when the DatePicker has no Calendar i.e. it is in TimePicker mode
-    if (self.selectedDates.length === 0 && self.config.noCalendar) {
+    if (self.selectedDates.length === 0) {
       const defaultDate =
         self.config.minDate === undefined ||
         compareDates(new Date(), self.config.minDate) >= 0
@@ -1601,8 +1601,8 @@ function FlatpickrInstance(
           self.timeContainer !== undefined &&
           self.minuteElement !== undefined &&
           self.hourElement !== undefined &&
-          self.input.value !== "" &&
-          self.input.value !== undefined
+          self._input.value !== "" &&
+          self._input.value !== undefined
         ) {
           updateTime();
         }


### PR DESCRIPTION
This PR fixes the DatePicker insconsistent behaviour when deleting dates manually in edit mode.

### What was happening
- In a date picker with edit mode on and time enabled, when trying to erase the input, it was set to the current date.
- In the `documentClick` event, the `updateTime()` method was being called when the input value was empty. This was making the time and date being set to their default values instead of remaining empty. 
- This occurred because the `self.input.value` was being used to check if the value was empty, but at this time, this property was not updated to the empty value yet.

### What was done
- Replaced the `self.input.value` to `self._input.value` that contains the updated value.

### Screenshots
Before: 
![gif2](https://github.com/OutSystems/flatpickr/assets/108938618/71bdbe23-e73a-48d1-8c54-daf0de6022b0)

After: 
![gif1](https://github.com/OutSystems/flatpickr/assets/108938618/cea61867-68c1-45b0-9412-87d5eb31cde7)
