### PR TITLE
ROU-10926: Fix Enter on Month and Time plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -472,6 +472,9 @@ function FlatpickrInstance(
         break;
       // Save the entered Date on the input
       case "Enter":
+        if(self.loadedPlugins.indexOf("monthSelect") !== -1|| self.config.noCalendar && self.config.enableTime) {
+          return;
+        }
         const newDate = new Date(self._input.value);
         setDate(newDate, true);
         break;


### PR DESCRIPTION
This PR fixes a regression on MonthPicker and TimePicker when pressing Enter on EditableInput.