### PR TITLE
ROU-11023: Fix month select issue when Enter key is pressed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -472,7 +472,10 @@ function FlatpickrInstance(
         break;
       // Save the entered Date on the input
       case "Enter":
-        if(self.loadedPlugins.indexOf("monthSelect") !== -1|| self.config.noCalendar && self.config.enableTime) {
+        if (
+          self.loadedPlugins.indexOf("monthSelect") !== -1 ||
+          (self.config.noCalendar && self.config.enableTime)
+        ) {
           return;
         }
         const newDate = new Date(self._input.value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1879,6 +1879,9 @@ function FlatpickrInstance(
 
         case 38:
         case 40:
+          if ((eventTarget as HTMLElement).tagName === "SELECT") {
+            break;
+          }
           e.preventDefault();
           const delta = e.keyCode === 40 ? 1 : -1;
           if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,6 +416,11 @@ function FlatpickrInstance(
    */
   function onYearInput(event: KeyboardEvent & IncrementEvent) {
     const eventTarget = getEventTarget(event) as HTMLInputElement;
+
+    if(eventTarget !== self.yearElements[0]) {
+      return;
+    }
+
     const year = parseInt(eventTarget.value) + (event.delta || 0);
 
     if (
@@ -2488,10 +2493,13 @@ function FlatpickrInstance(
     if (t === undefined) return;
 
     const target = t as DayElement;
+    const newDate = target ? new Date(target.dateObj.getTime()) : self.latestSelectedDateObj as Date;
 
-    const selectedDate = (self.latestSelectedDateObj = new Date(
-      target.dateObj.getTime()
-    ));
+    if(self.latestSelectedDateObj !== newDate) {
+      self.latestSelectedDateObj = newDate;
+    }
+
+    const selectedDate = newDate;
 
     const shouldChangeMonth =
       (selectedDate.getMonth() < self.currentMonth ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -689,9 +689,12 @@ function FlatpickrInstance(
     );
     self.calendarContainer.id =
       "flatpickr-calendar-" + self.utils.generateUniqueId();
-    self.calendarContainer.role = "dialog";
-    self.calendarContainer.ariaModal = "true";
-    self.calendarContainer.ariaLabel = self.l10n.ariaLabelCalendar;
+    self.calendarContainer.setAttribute("role", "dialog");
+    self.calendarContainer.setAttribute("ariaModal", "true");
+    self.calendarContainer.setAttribute(
+      "ariaLabel",
+      self.l10n.ariaLabelCalendar
+    );
     self.altInput?.setAttribute("aria-controls", self.calendarContainer.id);
     self.calendarContainer.tabIndex = -1;
 
@@ -1221,8 +1224,8 @@ function FlatpickrInstance(
     self.prevMonthNav.innerHTML = self.config.prevArrow;
     self.nextMonthNav.innerHTML = self.config.nextArrow;
 
-    self.prevMonthNav.ariaLabel = self.l10n.prevMonth;
-    self.nextMonthNav.ariaLabel = self.l10n.nextMonth;
+    self.prevMonthNav.setAttribute("ariaLabel", self.l10n.prevMonth);
+    self.nextMonthNav.setAttribute("ariaLabel", self.l10n.nextMonth);
 
     buildMonths();
 
@@ -1358,7 +1361,7 @@ function FlatpickrInstance(
       );
       self.amPM.title = self.l10n.toggleTitle;
       self.amPM.tabIndex = self.isOpen ? 0 : -1;
-      self.amPM.ariaLive = "polite";
+      self.amPM.setAttribute("ariaLive", "polite");
       self.timeContainer.appendChild(self.amPM);
     }
 
@@ -1491,7 +1494,7 @@ function FlatpickrInstance(
         self.calendarContainer.classList.remove("open");
       }
       if (self._input !== undefined) {
-        self._input.ariaExpanded = "false";
+        self._input.setAttribute("ariaExpanded", "false");
         self._input.classList.remove("active");
       }
     }
@@ -2079,7 +2082,7 @@ function FlatpickrInstance(
 
     if (!wasOpen) {
       self.calendarContainer.classList.add("open");
-      self._input.ariaExpanded = "true";
+      self._input.setAttribute("ariaExpanded", "true");
       self._input.classList.add("active");
       triggerEvent("onOpen");
       positionCalendar(positionElement);
@@ -2792,10 +2795,10 @@ function FlatpickrInstance(
       self.altInput.type = "text";
 
       // add accessibility attributes
-      self.altInput.role = "combobox";
-      self.altInput.ariaHasPopup = "true";
-      self.altInput.ariaAutoComplete = "none";
-      self.altInput.ariaExpanded = "false";
+      self.altInput.setAttribute("role", "combobox");
+      self.altInput.setAttribute("ariaHasPopup", "true");
+      self.altInput.setAttribute("ariaAutoComplete", "none");
+      self.altInput.setAttribute("ariaExpanded", "false");
 
       self.input.setAttribute("type", "hidden");
 

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -1,7 +1,7 @@
 export type Locale = {
-  nextMonth: string,
-  prevMonth: string,
-  ariaLabelCalendar: string,
+  nextMonth: string;
+  prevMonth: string;
+  ariaLabelCalendar: string;
   weekdays: {
     shorthand: [string, string, string, string, string, string, string];
     longhand: [string, string, string, string, string, string, string];
@@ -78,9 +78,9 @@ export type CustomLocale = {
   minuteAriaLabel?: string;
   amPM?: Locale["amPM"];
   time_24hr?: Locale["time_24hr"];
-  nextMonth: string,
-  prevMonth: string,
-  ariaLabelCalendar: string,
+  nextMonth: string;
+  prevMonth: string;
+  ariaLabelCalendar: string;
   weekdays: {
     shorthand: [string, string, string, string, string, string, string];
     longhand: [string, string, string, string, string, string, string];


### PR DESCRIPTION
This PR will fix the following issues:
- Compiled report issues;
- Lint;
- Fixed the issue that was causing year to be update when Enter key was pressed at the month select only if month didn't change;
- Improve the month selector in order to give the ability to open it also by using arrows up and down keys;

> **Preview:**
>> **With Issue**:
>>![dp-issue](https://github.com/user-attachments/assets/b1ff6631-50e9-435a-9c98-68979929795c)
>
>> **Fixed**:
>> ![dp-fixed](https://github.com/user-attachments/assets/61b6a556-a6a6-4512-8393-458881a86d32)
