### PR TITLE
ROU-11023: Match a missing default windows behaviour.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1836,7 +1836,11 @@ function FlatpickrInstance(
             e.preventDefault();
             updateTime();
             focusAndClose();
-          } else selectDate(e);
+          } else if ((eventTarget as HTMLElement).tagName === "SELECT") {
+            break;
+          } else {
+            selectDate(e)
+          };
 
           break;
 


### PR DESCRIPTION
This PR will fix a default behaviour when at windows in order to let Month select to be opened when enter is pressed.