### PR TITLE
Fix to onInputKeyDown -> "Enter" key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -484,7 +484,7 @@ function FlatpickrInstance(
           return;
         }
         const newDate = new Date(self.parseDate(self._input.value, self.config.altFormat));
-        setDate(newDate, true);
+        setDate(newDate, true, self.config.altFormat);
         break;
       // Close the calendar
       case "Tab":

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,7 +483,7 @@ function FlatpickrInstance(
         ) {
           return;
         }
-        const newDate = new Date(self._input.value);
+        const newDate = new Date(self.parseDate(self._input.value, self.config.altFormat));
         setDate(newDate, true);
         break;
       // Close the calendar


### PR DESCRIPTION
Fix to onInputKeyDown -> "Enter" key.

When a user inputs a date manually by typing it in the input (e.g. 24-12-2024), when clicking **enter**, the date is not saved. This happens because the date is not being parsed properly and therefore giving an invalid date. By implementing this change, it will fix the problem.

**ODC OSUI affected version:** 2.19.2