### PR TITLE
ROU-19854: Part2 - Improve inserted dates not being case sensitive.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2339,8 +2339,8 @@ function FlatpickrInstance(
 
     tokenRegex.D = `(${self.l10n.weekdays.shorthand.join("|")})`;
     tokenRegex.l = `(${self.l10n.weekdays.longhand.join("|")})`;
-    tokenRegex.M = "(" + self.l10n.months.shorthand.join("|") + "|" + self.l10n.months.shorthand.join("|").toLowerCase() + ")";
-    tokenRegex.F = "(" + self.l10n.months.longhand.join("|") + "|" + self.l10n.months.longhand.join("|").toLowerCase() + ")";
+    tokenRegex.M = "(" + self.l10n.months.shorthand.join("|") + ")";
+    tokenRegex.F = "(" + self.l10n.months.longhand.join("|") + ")";
     tokenRegex.K = `(${self.l10n.amPM[0]}|${
       self.l10n.amPM[1]
     }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -484,20 +484,9 @@ function FlatpickrInstance(
           return;
         }
 
-        // Get the input value
-        const inputValue = self._input.value.trim();
-        // With the input value, let's try to parse the date based on the defined altFormat
-        const newDate = self.parseDate(inputValue, self.config.altFormat) as Date;
-
-        // Check if the input is empty or the date is invalid, if so, prevent date to be set!
-        if (inputValue === "") {
-            return
-        } else if (isNaN(Number(newDate))) {
-            console.error("Inserted date is not valid");
-            return;
-        }
-
-        setDate(newDate, true);
+        self._input.blur();
+        self.close();
+        
         break;
       // Close the calendar
       case "Tab":

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -88,8 +88,8 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
         const escaped = format[i - 1] === "\\" || isBackSlash;
 
         if (tokenRegex[token] && !escaped) {
-          regexStr += tokenRegex[token];
-          const match = new RegExp(regexStr).exec(date);
+          regexStr += tokenRegex[token].toLowerCase();
+          const match = new RegExp(regexStr).exec(date.toLowerCase());
           if (match && (matched = true)) {
             ops[token !== "Y" ? "push" : "unshift"]({
               fn: revFormat[token],


### PR DESCRIPTION
This PR will fix an issue that was caused when:

- allowInput = true;

If user insert day/month names in lowercase selectDate method was not being able to properly set the date once those values was not being found at locale list of available options.

On top of this a functional issue was also fixed, when Enter key was pressed and DatePicker is in range mode (DatePikerRange) once Enter key is pressed the input gets set with the first inserted date only...