### PR TITLE
ROU-11798: Fixed aria attributes syntax errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -700,9 +700,9 @@ function FlatpickrInstance(
     self.calendarContainer.id =
       "flatpickr-calendar-" + self.utils.generateUniqueId();
     self.calendarContainer.setAttribute("role", "dialog");
-    self.calendarContainer.setAttribute("ariaModal", "true");
+    self.calendarContainer.setAttribute("aria-modal", "true");
     self.calendarContainer.setAttribute(
-      "ariaLabel",
+      "aria-label",
       self.l10n.ariaLabelCalendar
     );
     self.altInput?.setAttribute("aria-controls", self.calendarContainer.id);
@@ -1234,8 +1234,8 @@ function FlatpickrInstance(
     self.prevMonthNav.innerHTML = self.config.prevArrow;
     self.nextMonthNav.innerHTML = self.config.nextArrow;
 
-    self.prevMonthNav.setAttribute("ariaLabel", self.l10n.prevMonth);
-    self.nextMonthNav.setAttribute("ariaLabel", self.l10n.nextMonth);
+    self.prevMonthNav.setAttribute("aria-label", self.l10n.prevMonth);
+    self.nextMonthNav.setAttribute("aria-label", self.l10n.nextMonth);
 
     buildMonths();
 
@@ -1371,7 +1371,7 @@ function FlatpickrInstance(
       );
       self.amPM.title = self.l10n.toggleTitle;
       self.amPM.tabIndex = self.isOpen ? 0 : -1;
-      self.amPM.setAttribute("ariaLive", "polite");
+      self.amPM.setAttribute("aria-live", "polite");
       self.timeContainer.appendChild(self.amPM);
     }
 
@@ -1504,7 +1504,7 @@ function FlatpickrInstance(
         self.calendarContainer.classList.remove("open");
       }
       if (self._input !== undefined) {
-        self._input.setAttribute("ariaExpanded", "false");
+        self._input.setAttribute("aria-expanded", "false");
         self._input.classList.remove("active");
       }
     }
@@ -2099,7 +2099,7 @@ function FlatpickrInstance(
 
     if (!wasOpen) {
       self.calendarContainer.classList.add("open");
-      self._input.setAttribute("ariaExpanded", "true");
+      self._input.setAttribute("aria-expanded", "true");
       self._input.classList.add("active");
       triggerEvent("onOpen");
       positionCalendar(positionElement);
@@ -2816,9 +2816,9 @@ function FlatpickrInstance(
 
       // add accessibility attributes
       self.altInput.setAttribute("role", "combobox");
-      self.altInput.setAttribute("ariaHasPopup", "true");
-      self.altInput.setAttribute("ariaAutoComplete", "none");
-      self.altInput.setAttribute("ariaExpanded", "false");
+      self.altInput.setAttribute("aria-haspopup", "true");
+      self.altInput.setAttribute("aria-autocomplete", "none");
+      self.altInput.setAttribute("aria-expanded", "false");
 
       self.input.setAttribute("type", "hidden");
 


### PR DESCRIPTION
#### What was done

- Fixed some `aria` attributes syntax errors that were impacting accessibility
    - Example: 
![image](https://github.com/user-attachments/assets/2eeb3f73-6707-4a56-9159-98dee0e39a39)
 