### PR TITLE
ROU-12905: fix DatePicker onChange not firing on manual -1 day entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1776,9 +1776,19 @@ function FlatpickrInstance(
 
     if (self.config.altInput) {
       const hiddenInputValue = self.element.getAttribute("value") as string;
+      // Parse the hidden value with flatpickr's own parser (local time) rather
+      // than new Date(), whose date-only ("Y-m-d") parsing is treated as UTC and
+      // therefore shifts to the previous day under negative timezone offsets,
+      // making a one-day-earlier manual entry look unchanged and suppressing
+      // onChange. undefined => no valid baseline => treat the value as changed.
+      const parsedHiddenDate = self.parseDate(
+        hiddenInputValue,
+        self.config.dateFormat
+      );
       valueChanged =
+        parsedHiddenDate === undefined ||
         self._input.value.trimEnd() !==
-        self.formatDate(new Date(hiddenInputValue), self.config.altFormat);
+          self.formatDate(parsedHiddenDate, self.config.altFormat);
     }
 
     if (


### PR DESCRIPTION
## Summary

Fixes the DatePicker (flatpickr) failing to fire `onChange` when a user **manually types a date one day earlier** than the currently selected date, under **negative timezone offsets** 

## Root cause

`onBlur` gates whether to call `setDate(..., true, ...)` (which fires `onChange`) on a `valueChanged` check:

```ts
self.formatDate(new Date(hiddenInputValue), self.config.altFormat)
```

With `TimeFormat.Disabled` the hidden value is a date-only string (e.g. `"2026-06-25"`). Per ECMAScript, a date-only string passed to `new Date()` is parsed as **UTC midnight**. Under a negative UTC offset (e.g. UTC−02:00) that instant renders as the **previous day** in local time, so `formatDate(...)` returns `"2026-06-24"`.

Consequently, after selecting today and typing the previous day, the typed value equals the (shifted) baseline → `valueChanged = false` → `setDate`/`onChange` are skipped. Typing **−2 days** differs from the shifted baseline, so it still fires — matching the ticket's exact signature ("−1 fails, −2 works, negative offsets only").

## Fix

Parse the hidden value with flatpickr's own `self.parseDate(hiddenInputValue, self.config.dateFormat)`, which builds the date from **local** components (no UTC shift), consistent with the rest of flatpickr. An unparseable/empty value is treated as changed so `onChange` is not wrongly suppressed.

## Testing

- `npm run test:typecheck` — passes.
- `npm run test:unit` — **4 failed / 107 passed, identical to `master` baseline** (the same 4 pre-existing failures: `API destroy()`, `onKeyDown ... Enter`, `time-picker focuses out`, `onBlur doesn't misfire`). This change adds **no new failures**.
- `npm run build` — succeeds; fix present in `dist/flatpickr.js` and `dist/esm/index.js`.


